### PR TITLE
langcodes 3.5.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ about:
   summary: Tools for labeling human languages with IETF language tags
   license: MIT
   license_file: LICENSE.txt
+  license_family: MIT
   description: |
     Langcodes is a toolkit for working with and comparing the
      standardized codes for languages, such as 'en' for English, 'es'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,41 +1,52 @@
 {% set name = "langcodes" %}
-{% set version = "3.3.0" %}
-
+{% set version = "3.5.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/langcodes-{{ version }}.tar.gz
-  sha256: 794d07d5a28781231ac335a1561b8442f8648ca07cd518310aeb45d6f0807ef6
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1eef8168d07e51e131a2497ffecad4b663f6208e7c3ae3b8dc15c51734a6f801
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - pip
-    - setuptools
+    - setuptools >=60
+    - setuptools-scm >=8.0
     - wheel
-    - poetry
     - python
   run:
-    - python >=3.6
+    - python
+    - language-data >=1.2
 
 test:
+  source_files:
+    - langcodes/tests
   imports:
     - langcodes
-  commands:
-    - pip check
+    - langcodes.data_dicts
+    - langcodes.language_distance
+    - langcodes.language_lists
+    - langcodes.registry_parser
+    - langcodes.tag_parser
+    - langcodes.util
   requires:
     - pip
+    - pytest
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+
 
 about:
-  home: http://github.com/rspeer/langcodes
-  summary: Labels and compares human languages in a standardized way
+  home: https://github.com/georgkrause/langcodes
+  summary: Tools for labeling human languages with IETF language tags
   license: MIT
   license_file: LICENSE.txt
   description: |
@@ -43,7 +54,8 @@ about:
      standardized codes for languages, such as 'en' for English, 'es'
      for Spanish, and 'zh-Hant' for Traditional Chinese. These are
      BCP 47 language codes, formerly known as ISO language codes.
-
+  dev_url: https://github.com/georgkrause/langcodes
+  doc_url: https://github.com/georgkrause/langcodes/tree/main/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-
+    - pytest -ra -vv langcodes/tests
 
 about:
   home: https://github.com/georgkrause/langcodes


### PR DESCRIPTION
langcodes 3.5.0 

**Destination channel:** Defaults

### Links

- [PKG-9441]
- dev_url:        https://github.com/georgkrause/langcodes/tree/v3.5.0
- conda_forge:    https://github.com/conda-forge/langcodes-feedstock
- pypi:           https://pypi.org/project/langcodes/3.5.0
- pypi inspector: https://inspector.pypi.io/project/langcodes/3.5.0

### Explanation of changes:

- new version number


[PKG-9441]: https://anaconda.atlassian.net/browse/PKG-9441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ